### PR TITLE
update url to seechange.codeforaustralia.org

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -2,7 +2,7 @@
   "name": "client",
   "version": "0.1.0",
   "private": true,
-  "homepage": "https://codeforaustralia.github.io/civic-makers-climate-change-visualization/",
+  "homepage": "https://seechange.codeforaustralia.org",
   "dependencies": {
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",


### PR DESCRIPTION
## Why

now that a CNAME record has been created to point `seechange.codeforaustralia.org` to `codeforaustralia.github.io.` (see trello card https://trello.com/c/OqxkVZzb/27-set-up-domain-name), this change is required to ensure our react app (router?) uses the new subdomain.

FYI, need to run `npm run deploy` to redeploy app after merging this change